### PR TITLE
Ensure SecureSocket::onActivated is called for all available data

### DIFF
--- a/MqttClient.cpp
+++ b/MqttClient.cpp
@@ -216,7 +216,7 @@ void MqttClient::onActivated(int)
         std::string data;
         if (p->expectedSize != 0) {
             if (p->buffer.size() < p->expectedSize)
-                break;
+                return;
 
             data = std::string(p->buffer.begin(), p->buffer.begin() + p->expectedSize);
             p->buffer.erase(p->buffer.begin(), p->buffer.begin() + p->expectedSize);
@@ -244,12 +244,6 @@ void MqttClient::onActivated(int)
             default:
                 std::cerr  << "unhandled message type " << frame.type << std::endl;
         }
-    }
-
-    //have more?
-    //TODO wont get activated again. this is not properly abstracted away in SecureSocket
-    if (r >= 200) {
-        onActivated(0);
     }
 }
 

--- a/SecureSocket.cpp
+++ b/SecureSocket.cpp
@@ -42,6 +42,12 @@ public:
             d_connect();
         } else if (state == Kite::SecureSocket::Connected) {
             p->onActivated(0);
+            if (BIO_pending(bio)) {
+                Timer::later(ev(), [this](){
+                    onActivated(0);
+                    return false;
+                }, 1, "BIO_pending after read");
+            }
         }
     }
     friend class Kite::SecureSocket;


### PR DESCRIPTION
TLS BIOs consume all data from fds and don't trigger poll events again.
Also removes previous workarounds in MqttClient.
